### PR TITLE
Add support for reading stopwords from file

### DIFF
--- a/t/attributes.t
+++ b/t/attributes.t
@@ -31,8 +31,9 @@ sub get_content {
           },
           [GatherDir =>],
           [$name => $args],
-        )
-      }
+        ),
+        'source/.stopwords' => " yoyo\nnibster  ", # spaces should be trimmed
+      },
     }
   );
 
@@ -63,5 +64,10 @@ $content = get_content({spell_cmd => 'all_wrong'});
 
 $content = get_content({stopwords => 'foohoo'});
   like $content, qr/__DATA__\s(.*\s)*foohoo\b/,   q[add stopwords];
+
+$content = get_content({stopwords_file => '.stopwords'});
+  cmp_deeply([ get_stopwords($content) ],
+             superbagof($fname, $lname, 'yoyo', 'nibster'),
+             'DATA handle includes stopwords from file');
 
 done_testing;


### PR DESCRIPTION
Add a new attribute: `stopwords_file`.  It should be the path a file
that contains stopwords, one per line.  Leading and trailing white
space is trimmed.

Added pod for the attribute.

Added a test, providing a stopwords file that contains words with some
funny whitespace results in the expected list of stopwords (sans
extraneous whitespace).

I tried to match your indentation, etc... but I'm not sure how you
tidy your files, didn't see any perltidy settings.