### PR TITLE
remove direct dependency on Test::Spelling

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,7 +20,6 @@ x_IRC = irc://irc.perl.org/#distzilla
 x_MailingList = http://dzil.org/#mailing-list
 
 [Prereqs]
-Test::Spelling = 0.12
 Dist::Zilla    = 5
 
 [Test::CheckBreaks]


### PR DESCRIPTION
This module doesn't use Test::Spelling directly. The test it generates does, but using the plugin itself doesn't need it. Using the plugin adds a develop prereq on the module, which should be installed before running xt tests.